### PR TITLE
Add Sphinx Domain to project classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3.12",
     "Framework :: Sphinx",
+    "Framework :: Sphinx :: Domain",
     "Framework :: Sphinx :: Extension",
     "Topic :: Documentation",
     "Topic :: Documentation :: Sphinx",


### PR DESCRIPTION
## Summary of changes

- Add Sphinx Domain to project classifiers to make it easier for people to find on [Domains](https://www.sphinx-doc.org/en/master/usage/domains/index.html), [PyPi](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Domain), etc